### PR TITLE
Fixed breaking wrong member declaration order

### DIFF
--- a/models/srmodel.py
+++ b/models/srmodel.py
@@ -159,12 +159,12 @@ class SRModel(pl.LightningModule, ABC):
         self._last_epoch = max_epochs
         self._log_loss_every_n_epochs = log_loss_every_n_epochs
         self._log_weights_every_n_epochs = log_weights_every_n_epochs
+        self._save_hd_versions = None
         self._losses = self._create_losses(losses, patch_size, precision)
         self._metrics = self._create_metrics(metrics)
         self._metrics_for_pbar = metrics_for_pbar
         self._optim, self._optim_params = self._parse_optimizer_config(optimizer, optimizer_params)
         self._predict_datasets = predict_datasets
-        self._save_hd_versions = None
         self._save_results = save_results
         self._save_results_from_epoch = save_results_from_epoch
         self._scale_factor = scale_factor


### PR DESCRIPTION
After #01ed3eb, the initialization of `_losses` has been moved above `_save_hd_versions`, which ended up breaking the the program, due to `_create_losses()` accessing `_save_hd_versions`, which now does not exist yet during its call.

Reproduction of error in Python 3.8:
```
Log level: INFO
Created a temporary directory at /tmp/tmpijlk_yz7
Writing /tmp/tmpijlk_yz7/_remote_module_non_sriptable.py
1.000 * adaptive
Traceback (most recent call last):
  File "train.py", line 325, in <module>
    main(Model, args)
  File "train.py", line 150, in main
    model = Model(**vars(args))
  File "/root/tcc_ultimate/models/edsr.py", line 27, in __init__
    super(EDSR, self).__init__(**kwargs)
  File "/root/tcc_ultimate/models/srmodel.py", line 162, in __init__
    self._losses = self._create_losses(losses, patch_size, precision)
  File "/root/tcc_ultimate/models/srmodel.py", line 487, in _create_losses
    if self._save_hd_versions is None:
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1185, in __getattr__
    raise AttributeError("'{}' object has no attribute '{}'".format(
AttributeError: 'EDSR' object has no attribute '_save_hd_versions'
```