### PR TITLE
Add test and measurement pipeline steps

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,69 @@
+import argparse
+import json
+from skimage.metrics import structural_similarity as calculate_ssim
+from skimage.metrics import peak_signal_noise_ratio as calculate_psnr
+import cv2
+import numpy as np
+from os import listdir
+from statistics import mean
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Evaluate image quality.')
+    parser.add_argument('--datasets_dir', type=str)
+    parser.add_argument('--default_root_dir', type=str) 
+    parser.add_argument('--original_datasets', type=str) 
+    parser.add_argument('--predict_datasets', type=str) 
+
+    args = parser.parse_args()
+    original_dir = f'{args.datasets_dir}/{args.original_datasets}'
+    sr_dir = f'{args.default_root_dir}/{args.predict_datasets}'
+
+    original_imgs = sorted(listdir(original_dir))
+    original_imgs = [x.split('.')[0] for x in original_imgs] # remove extensions
+
+    ssim_scores = []
+    psnr_scores = []
+    for i in range(len(original_imgs)): # Both should have the same size
+        before = cv2.imread(f'{original_dir}/{original_imgs[i]}')
+        after = cv2.imread(f'{sr_dir}/{original_imgs[i]+".png"}')
+
+        # Convert images to grayscale
+        # before_gray = cv2.cvtColor(before, cv2.COLOR_BGR2GRAY)
+        # after_gray = cv2.cvtColor(after, cv2.COLOR_BGR2GRAY)
+
+        # Compute SSIM between two images
+        (ssim_score, ssim_diff) = calculate_ssim(before, after, channel_axis=2, full=True)
+        ssim_scores.append(ssim_score)
+        psnr_score = calculate_psnr(before, after)
+        psnr_scores.append(psnr_score)
+
+    # Data to be written
+    psnr = {
+        'scores': psnr_scores,
+        'mean': mean(psnr_scores),
+        'max': psnr_scores.index(max(psnr_scores))
+    }
+    ssim = {
+        'scores': ssim_scores,
+        'mean': mean(ssim_scores),
+        'max': ssim_scores.index(max(ssim_scores))
+    }
+    data = {
+        'psnr' : psnr,
+        'ssim': ssim
+    }
+
+    print(f'--- PSNR ---')
+    print(f'Mean: {psnr["mean"]}')
+    print(f'Max: {psnr["scores"][psnr["max"]]}, {psnr["max"]})th image (0-indexed)')
+    print(f'--- SSIM ---')
+    print(f'Mean: {ssim["mean"]}')
+    print(f'Max: {ssim["scores"][ssim["max"]]}, {ssim["max"]})th image (0-indexed)')
+
+    # Serializing json
+    json_object = json.dumps(data, indent=4)
+    
+    # Writing to sample.json
+    with open(f'{args.default_root_dir}/metrics.json', "w") as outfile:
+        outfile.write(json_object)
+

--- a/predict.py
+++ b/predict.py
@@ -187,6 +187,7 @@ if __name__ == '__main__':
                         choices=tuple(available_models),
                         default='srcnn')
     parser.add_argument('-s', '--scale_factor', type=int, default=4)
+    parser.add_argument('-w', '--predict_whole_img', action=argparse.BooleanOptionalAction)
     args, remaining = parser.parse_known_args()
 
     # load model class

--- a/srdata.py
+++ b/srdata.py
@@ -168,8 +168,9 @@ class _SRDatasetFromDirectory(Dataset):
             img_lr = Image.open(self._lr_filenames[index]).convert('RGB')
             img_lr, img_hr = self._get_patch(img_lr, img_hr, self._patch_size, self._scale_factor)
 
-        assert img_lr.size[-2] == img_hr.size[-2] // self._scale_factor and \
-            img_lr.size[-1] == img_hr.size[-1] // self._scale_factor
+        if not self._predict_whole_img:
+            assert img_lr.size[-2] == img_hr.size[-2] // self._scale_factor and \
+                img_lr.size[-1] == img_hr.size[-1] // self._scale_factor
 
         return {'lr': TF.to_tensor(img_lr), 'hr': TF.to_tensor(img_hr), 'path': filename.stem}
 
@@ -202,6 +203,8 @@ class _SRDatasetFromDirectory(Dataset):
         lr_patch = TF.crop(lr_image, lr_x, lr_y, lr_patch_size, lr_patch_size)
         hr_patch = TF.crop(hr_image, hr_x, hr_y, patch_size, patch_size)
 
+        if self._predict_whole_img:
+            return lr_image, hr_patch
         return lr_patch, hr_patch
 
 
@@ -334,6 +337,7 @@ class SRData(LightningDataModule):
         self._scale_factor = args.scale_factor
         self._train_datasets = None
         self._train_datasets_names = args.train_datasets.copy()
+        self._predict_whole_img = args.predict_whole_img
 
         if 'batch_size' in args:
             self._batch_size = args.batch_size


### PR DESCRIPTION
# Context
For the scope of my Final Paper, I've continued your work by finishing the test (prediction) with an extra measurement step, which takes the average PSNR and SSIM score for the resulting super-resolved image from each model, and saves it into a JSON within the experiment folder of that specific model. This is all done in "metrics.py", which expects a folder with the original HR images.

I've also fixed an unintended bug in start_here.sh where the folder name casing where the experiments are saved from the training, were not coherent with how they are expected in your predict.py.

## NT: This diff is incomplete for merging, and I'd like guidance how to proceed.
I manually downscaled all images I used to predict. They were 256x256 images of galaxies, and I downscaled them using bicubic to 128x128. First, I had ran training of models using DIV2K, with patches sized 128, and factor of 2. But whenever I tried running the tests pointing to the Galaxy datasource, I had errors because it tried to cut patches from it.

For the purposes of finishing tests, I conditionally excluded the lines that were causing it (with a flag) in SRData. I don't understand well why it didn't work, but it seems it's because my LR images already are the size of the patches.

## Other improvements to be made before merging
- Properly add new dependencies (from metrics.py) to the Docker Image.
- Consider not using a flag.